### PR TITLE
Delete account page

### DIFF
--- a/app/controllers/settings/account_controller.rb
+++ b/app/controllers/settings/account_controller.rb
@@ -21,7 +21,7 @@ module Settings
         flash[:notice] = "Your account has been deleted"
         redirect_to root_app_url
       else
-        current_user.errors.add(:base, "Your password was incorrect")
+        current_user.errors.add(:current_password, "Incorrect Password")
         render :delete
       end
     end

--- a/app/controllers/settings/account_controller.rb
+++ b/app/controllers/settings/account_controller.rb
@@ -11,11 +11,19 @@ module Settings
       end
     end
 
+    def delete # confirm destroy page
+    end
+
     def destroy
-      current_user.update(deleted_at: Time.zone.now)
-      sign_out :user
-      flash[:notice] = "Your account has been deleted"
-      redirect_to root_app_url
+      if current_user.authenticated?(destroy_params[:current_password])
+        current_user.update(deleted_at: Time.zone.now)
+        sign_out
+        flash[:notice] = "Your account has been deleted"
+        redirect_to root_app_url
+      else
+        current_user.errors.add(:base, "Your password was incorrect")
+        render :delete
+      end
     end
 
     private
@@ -24,6 +32,10 @@ module Settings
       params.require(:user).permit(:first_name, :last_name, :username, :email,
         :notification_frequency, :avatar,
         :job_title, :phone, :skype, :bio, :current_password)
+    end
+
+    def destroy_params
+      params.require(:user).permit(:current_password)
     end
   end
 end

--- a/app/views/settings/account/delete.html.erb
+++ b/app/views/settings/account/delete.html.erb
@@ -1,0 +1,30 @@
+<div class="pure-g">
+  <div class="pure-u-1 pure-u-md-8-24 pure-u-lg-6-24">
+    <%= render "settings/menu" %>
+  </div>
+
+  <div class="pure-u-1 pure-u-md-1-24"></div>
+
+  <div class="pure-u-1 pure-u-md-15-24 pure-u-lg-17-24">
+    <h1>Delete Account</h1>
+
+    <p>We're sorry to see you leave!</p>
+    <p>If you're sure you want to delete your account, please confirm your password below.</p>
+
+    <%= simple_form_for current_user, url: settings_account_path, method: :delete do |f| %>
+      <%= render 'shared/form_errors', object: f.object %>
+
+      <div class="form-inputs account-settings">
+        <div class="pure-g">
+          <div class="pure-u-1 pure-u-md-1-2 pure-u-lg-1-3">
+            <%= f.input :current_password, required: true, autofocus: true %>
+          </div>
+        </div>
+      </div>
+
+      <div class="form-actions">
+        <%= f.button :submit, "Delete my account", class: "btn btn-main" %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/settings/account/edit.html.erb
+++ b/app/views/settings/account/edit.html.erb
@@ -90,7 +90,7 @@
       </div>
     <% end %>
 
-    <p>Unhappy with this service? You can <%= link_to "delete your account", settings_account_path, data: { confirm: "Are you sure?" }, method: :delete %> at any time.</p>
+    <p>Unhappy with this service? You can <%= link_to "delete your account", delete_settings_account_path %> at any time.</p>
 
   </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -33,7 +33,9 @@ Rails.application.routes.draw do
     get "/settings", to: redirect('/settings/account/edit'), as: :settings
     namespace :settings do
       resource :password, only: [:show, :create]
-      resource :account, only: [:edit, :update, :destroy], controller: :account
+      resource :account, only: [:edit, :update, :destroy], controller: :account do
+        get "delete"
+      end
       resources :teams, only: [:show, :new, :create, :update] do
         delete "leave", on: :member
       end

--- a/lib/sign_in_guards/is_team_member_guard.rb
+++ b/lib/sign_in_guards/is_team_member_guard.rb
@@ -3,15 +3,15 @@ module SignInGuards
     def call
       # current_team will be nil when signing in from the root domain
       # on first signup
-      if current_team.nil? || member_of_team?
-        next_guard
-      else
+      if signed_in? && !member_of_team?
         failure("You’re not a member of #{current_team.name}")
+      else
+        next_guard
       end
     end
 
     def member_of_team?
-      signed_in? && current_team.users.exists?(current_user.id)
+      current_team.nil? || current_team.users.exists?(current_user.id)
     end
 
     private

--- a/lib/sign_in_guards/not_deleted_guard.rb
+++ b/lib/sign_in_guards/not_deleted_guard.rb
@@ -1,10 +1,10 @@
 module SignInGuards
   class NotDeletedGuard < ::Clearance::SignInGuard
     def call
-      if signed_in? && current_user.deleted_at.nil?
-        next_guard
-      else
+      if signed_in? && current_user.deleted_at.present?
         failure("Your account has been archived.")
+      else
+        next_guard
       end
     end
   end


### PR DESCRIPTION
- added a confirm delete account page, where the user must enter their password to delete
- rearranged the sign in guards, with failures first. Previously if a user did not sign in successfully, they were getting caught in the custom guards, and being thrown incorrect failure messages.