### PR TITLE
Bugfix for first human_time not loading

### DIFF
--- a/app/assets/javascripts/directives/human_time.js
+++ b/app/assets/javascripts/directives/human_time.js
@@ -1,14 +1,14 @@
 angular.module("OpenHq").directive("humanTime", function() {
-    return {
-        restrict: "E",
-        scope: {
-          datetime: '=',
-        },
-        template: "<abbr title='{{ datetime }}'>{{ datetime }}</abbr>",
-        link: function($scope, el){
-            $scope.$watch('datetime', function(){
-                $(el).find('abbr').timeago();
-            });
-        },
-    };
+  return {
+    restrict: "E",
+    scope: {
+      datetime: '=',
+    },
+    template: "<abbr title='{{ datetime }}'>{{ datetime }}</abbr>",
+    link: function($scope, el){
+      $scope.$watch('datetime', function(){
+        if ($scope.datetime) $(el).find('abbr').timeago();
+      });
+    },
+  };
 });


### PR DESCRIPTION
First `<human-time>` tag on the page wasn’t always loading in right, $scope.datetime was undefined on first page load and when we set up timeago it already registered a load but had no timestamp to set it up for, then when it was called again it didn’t load timeago cause it was already setup.